### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete string escaping or encoding

### DIFF
--- a/lib/aibika.rb
+++ b/lib/aibika.rb
@@ -661,7 +661,7 @@ module Aibika
       sb.setenv('GEM_PATH', (TEMPDIR_ROOT / GEMHOMEDIR).to_native)
 
       # Add the opcode to launch the script
-      extra_arg = Aibika.arg.map { |arg| " \"#{arg.gsub('"', '\"')}\"" }.join
+      extra_arg = Aibika.arg.map { |arg| " \"#{arg.gsub('\\', '\\\\').gsub('"', '\"')}\"" }.join
       installed_ruby_exe = TEMPDIR_ROOT / BINDIR / rubyexe
       launch_script = (TEMPDIR_ROOT / target_script).to_native
       sb.postcreateprocess(installed_ruby_exe,


### PR DESCRIPTION
Potential fix for [https://github.com/tamatebako/aibika/security/code-scanning/4](https://github.com/tamatebako/aibika/security/code-scanning/4)

To fix this problem, each argument interpolated into a double-quoted string must have both double quotes and backslashes escaped; otherwise, strings containing either character may be misinterpreted. This is achieved by replacing each backslash (`\`) with two (`\\`), *then* each double-quote (`"`) with `\"`, typically done with two `gsub` calls (or a single call using a regular expression and a block, if preferred). The order is important: always escape backslashes *first*, then double quotes, since otherwise the quote escaping might itself contain a backslash. The change should be applied at line 664 of `lib/aibika.rb`, where the argument escaping is currently implemented.

No new methods or imports are necessary, as all required Ruby methods (`gsub`) are available by default.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
